### PR TITLE
Updated motion lighting template select to include light groups

### DIFF
--- a/nodes/modules/system/domain/models/template/dynamic/area/motion/lighting/MotionLightingHybridTargetAreaTemplateSelect.js
+++ b/nodes/modules/system/domain/models/template/dynamic/area/motion/lighting/MotionLightingHybridTargetAreaTemplateSelect.js
@@ -34,9 +34,10 @@ class MotionLightingHybridTargetAreaTemplateSelect extends AreaTemplate {
       - name: "Motion Lighting Hybrid Target ${area_name}"
         state: "{{ states('input_text.motion_lighting_hybrid_target_state_${area_id}') }}"
         options: >
-          {{ expand(area_entities("${area_id}"))
+          {{ states
           | selectattr('domain', 'eq', 'light')
-          | map(attribute='name') | list }}
+          | selectattr('entity_id', 'in', area_entities('${area_id}'))
+          | map(attribute='name')| list }}
         select_option:
           - service: input_text.set_value
             target:

--- a/nodes/modules/system/domain/models/template/dynamic/area/motion/lighting/MotionLightingTargetAreaTemplateSelect.js
+++ b/nodes/modules/system/domain/models/template/dynamic/area/motion/lighting/MotionLightingTargetAreaTemplateSelect.js
@@ -34,9 +34,10 @@ class MotionLightingTargetAreaTemplateSelect extends AreaTemplate {
       - name: "Motion Lighting Target ${area_name}"
         state: "{{ states('input_text.motion_lighting_target_state_${area_id}') }}"
         options: >
-          {{ expand(area_entities("${area_id}"))
+          {{ states
           | selectattr('domain', 'eq', 'light')
-          | map(attribute='name') | list }}
+          | selectattr('entity_id', 'in', area_entities('${area_id}'))
+          | map(attribute='name')| list }}
         select_option:
           - service: input_text.set_value
             target:

--- a/nodes/modules/system/test/unit/domain/templates/mocks/motion_lighting_hybrid_target_area1_template_select.yaml
+++ b/nodes/modules/system/test/unit/domain/templates/mocks/motion_lighting_hybrid_target_area1_template_select.yaml
@@ -3,9 +3,10 @@ template:
       - name: "Motion Lighting Hybrid Target Area 1"
         state: "{{ states('input_text.motion_lighting_hybrid_target_state_area1') }}"
         options: >
-          {{ expand(area_entities("area1"))
+          {{ states
           | selectattr('domain', 'eq', 'light')
-          | map(attribute='name') | list }}
+          | selectattr('entity_id', 'in', area_entities('area1'))
+          | map(attribute='name')| list }}
         select_option:
           - service: input_text.set_value
             target:

--- a/nodes/modules/system/test/unit/domain/templates/mocks/motion_lighting_target_area1_template_select.yaml
+++ b/nodes/modules/system/test/unit/domain/templates/mocks/motion_lighting_target_area1_template_select.yaml
@@ -3,9 +3,10 @@ template:
       - name: "Motion Lighting Target Area 1"
         state: "{{ states('input_text.motion_lighting_target_state_area1') }}"
         options: >
-          {{ expand(area_entities("area1"))
+          {{ states
           | selectattr('domain', 'eq', 'light')
-          | map(attribute='name') | list }}
+          | selectattr('entity_id', 'in', area_entities('area1'))
+          | map(attribute='name')| list }}
         select_option:
           - service: input_text.set_value
             target:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization

## Description
### Who 
@david-okeke1337 
### What
Updated motion lighting template selects to include light groups
### Why
So that light groups created via the UI can be selected in motion lighting automations
## Related Tickets & Documents
Fixed on site @ Stu
- Related Issue #

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
